### PR TITLE
0.0.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,14 @@
 default_install_hook_types:
-    - pre-commit
+  - pre-commit
+  - pre-push
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-    -   id: check-toml
-    -   id: check-yaml
+      - id: check-toml
+      - id: check-yaml
+  - repo: https://github.com/ipear3/pre-commit-hook-poetry-auto-semver
+    # TODO: Use revision >=0.0.3
+    rev: '0.0.2'
+    hooks:
+      - id: poetry-auto-semver

--- a/pre_commit_hook_poetry_auto_semver/poetry_auto_semver.py
+++ b/pre_commit_hook_poetry_auto_semver/poetry_auto_semver.py
@@ -9,14 +9,14 @@ def get_latest_git_tag(
         default: str = "0.0.0"
 ) -> str:
     try:
-        process_output = subprocess.check_output(["git", "describe", "--tags"])
+        process_output = subprocess.check_output("git describe --tags --abbrev=0")
         tag = process_output.strip().decode()
     except subprocess.CalledProcessError:
         if default_or_error == "default":
             print(f"No git tag found. Using default git tag {default}.")
             tag = default
         elif default_or_error == "error":
-            raise AssertionError("git describe --tags failed to return a tag.")
+            raise AssertionError("git describe --tags --abbrev=0 failed to return a tag.")
         else:
             raise ValueError("default_or_error should be 'default' or 'error'")
     return tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pre_commit_hook_poetry_auto_semver"
-version = "0.0.2"
+version = "0.0.3"
 description = ""
 authors = ["Ian Pearthree <52967928+ipear3@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
- Add `poetry-auto-semver` to pre-commit hooks run
- Fix `Shouldn't bump project version. Poetry project version: 0.0.2 > Git tag version: 0.0.2-3-g534c261` by changing `git describe --tags` to `git describe --tags --abbrev=0`